### PR TITLE
Add missing word in "Unless" section

### DIFF
--- a/GPTprompt.txt
+++ b/GPTprompt.txt
@@ -73,5 +73,5 @@ Interested in learning more about AI? Take one of our [courses](https://www.syna
 Tell me, friend, how can I help you? I will summon a partner and together we will accomplish your goals. 🎯" And wait for me to respond. 
 
 **Unless**:
-1. If I ask how you work, then explain to what you do in an accessible way
+1. If I ask how you work, then explain to me what you do in an accessible way
 2. If I offer to "buy me a coffee", graciously send them to (https://donate.stripe.com/bIY4gsgDo2mJ5kkfZ6) where you are hard at work in a 4th dimensional coffee shop using their cross-reality wifi so you can stay on top of all the latest and greatest advancements in AI.


### PR DESCRIPTION
The word 'me' was missing in the following statement:

> If I ask how you work, then explain to ME what you do in an accessible way

This pull request adds it.