### PR TITLE
fix: handle new GitHub blob payload structure + vertical frontmatter tables

### DIFF
--- a/professor-synapse/scripts/github_blob_parser.py
+++ b/professor-synapse/scripts/github_blob_parser.py
@@ -13,76 +13,84 @@ def convert_frontmatter_table_to_yaml(markdown):
     """
     GitHub renders YAML frontmatter as an HTML table.
     This converts the resulting markdown table back to YAML frontmatter.
-    
-    Detects pattern:
-        key1 | key2 | key3
-        ---|---|---
-        val1 | val2 | val3
-    
+
+    GitHub's layout is 2-column vertical (key in col 0, value in col 1),
+    where the first key/value pair is embedded in the header row:
+
+        name | professor-synapse
+        ---|---
+        description | Use when ...
+        tags | foo, bar
+
     Converts to:
         ---
-        key1: val1
-        key2: val2
-        key3: val3
+        name: professor-synapse
+        description: Use when ...
+        tags: foo, bar
         ---
     """
     lines = markdown.split('\n')
-    
+
     # Need at least 3 lines for a frontmatter table
     if len(lines) < 3:
         return markdown
-    
-    # Check if first line looks like a header row (word | word | ...)
-    header_line = lines[0].strip()
-    if '|' not in header_line:
+
+    def split_row(line):
+        # Trim trailing markdown hard-break ("  ") and leading/trailing pipes
+        parts = [p.strip() for p in line.strip().rstrip('|').lstrip('|').split('|')]
+        return [p for p in parts if p != '']
+
+    # First row must have exactly 2 cells (key | value)
+    first = split_row(lines[0])
+    if len(first) != 2:
         return markdown
-    
-    # Check if second line is separator (---|---|...)
-    separator_line = lines[1].strip()
-    if not re.match(r'^[\s\-|]+$', separator_line) or '|' not in separator_line:
+
+    # Separator must be second line: ---|---
+    sep = lines[1].strip()
+    if not re.match(r'^[\s\-|]+$', sep) or '|' not in sep:
         return markdown
-    
-    # Check if third line has values
-    value_line = lines[2].strip()
-    if '|' not in value_line:
+
+    # Validate that at least one plausible frontmatter key is present
+    frontmatter_keys = {'name', 'description', 'title', 'author', 'date', 'tags',
+                        'license', 'version', 'compatibility'}
+
+    pairs = [(first[0], first[1])]
+    end_index = 2
+
+    # Consume additional 2-column rows until we hit a non-table line
+    for i in range(2, len(lines)):
+        row_text = lines[i].strip()
+        if row_text == '' or row_text.replace(' ', '') == '':
+            end_index = i
+            break
+        cells = split_row(lines[i])
+        if len(cells) != 2:
+            end_index = i
+            break
+        pairs.append((cells[0], cells[1]))
+        end_index = i + 1
+
+    # Require at least one recognized frontmatter key to avoid false positives
+    if not any(k.lower() in frontmatter_keys for k, _ in pairs):
         return markdown
-    
-    # Parse the table
-    headers = [h.strip() for h in header_line.split('|')]
-    values = [v.strip() for v in value_line.split('|')]
-    
-    # Filter out empty strings from split
-    headers = [h for h in headers if h]
-    values = [v for v in values if v]
-    
-    # Must have matching counts and look like frontmatter keys
-    if len(headers) != len(values):
-        return markdown
-    
-    # Common frontmatter keys to validate this is actually frontmatter
-    frontmatter_keys = {'name', 'description', 'title', 'author', 'date', 'tags', 'license', 'version', 'compatibility'}
-    if not any(h.lower() in frontmatter_keys for h in headers):
-        return markdown
-    
+
     # Build YAML frontmatter
     yaml_lines = ['---']
-    for key, value in zip(headers, values):
-        # Handle multi-line or complex values
+    for key, value in pairs:
         if '\n' in value or ':' in value or value.startswith('['):
-            yaml_lines.append(f'{key}: "{value}"')
+            escaped = value.replace('"', '\\"')
+            yaml_lines.append(f'{key}: "{escaped}"')
         else:
             yaml_lines.append(f'{key}: {value}')
     yaml_lines.append('---')
     yaml_lines.append('')
-    
-    # Join with rest of document (skip the 3 table lines)
-    rest_of_doc = '\n'.join(lines[3:]).lstrip('\n')
-    
+
+    rest_of_doc = '\n'.join(lines[end_index:]).lstrip('\n')
     return '\n'.join(yaml_lines) + rest_of_doc
 
 def main():
     content = sys.stdin.read()
-    
+
     # Find embedded JSON data
     match = re.search(
         r'<script type="application/json" data-target="react-app\.embeddedData">(.*?)</script>',
@@ -92,70 +100,85 @@ def main():
     if not match:
         print('Error: Could not find embedded data in GitHub page', file=sys.stderr)
         sys.exit(1)
-    
+
     try:
         data = json.loads(match.group(1))
         payload = data.get('payload', {})
-        blob = payload.get('blob', {})
-        rich_text = blob.get('richText', '')
-        
+        # New GitHub structure (2025+): data split across routes
+        # Markdown rich text lives in codeViewBlobRoute
+        # Raw lines for non-markdown live in codeViewBlobLayoutRoute.StyledBlob
+        blob = (
+            payload.get('codeViewBlobRoute')
+            or payload.get('blob')
+            or {}
+        )
+        styled_blob = (
+            payload.get('codeViewBlobLayoutRoute.StyledBlob')
+            or payload.get('codeViewBlobLayoutRoute', {}).get('blob')
+            or {}
+        )
+        rich_text = blob.get('richText') or ''
+
         if not rich_text:
             # Try rawLines for non-markdown files (scripts, etc.)
-            raw_lines = blob.get('rawLines')
+            raw_lines = (
+                styled_blob.get('rawLines')
+                or blob.get('rawLines')
+            )
             if raw_lines:
                 print('\n'.join(raw_lines))
                 sys.exit(0)
             print('Error: No content found in blob', file=sys.stderr)
             sys.exit(1)
-        
+
         # Convert HTML to Markdown
         try:
             import html2text
         except ImportError:
             print('Error: html2text not installed. Run: pip install html2text', file=sys.stderr)
             sys.exit(1)
-        
+
         h = html2text.HTML2Text()
         h.ignore_links = False
         h.ignore_images = True
         h.body_width = 0
         h.unicode_snob = True
-        
+
         markdown = h.handle(rich_text)
-        
+
         # === POST-PROCESSING FOR CLEANER OUTPUT ===
-        
+
         # Fix YAML frontmatter that was rendered as a table
         markdown = convert_frontmatter_table_to_yaml(markdown)
-        
+
         # Fix horizontal rules: '* * *' -> '---'
         markdown = re.sub(r'^\* \* \*$', '---', markdown, flags=re.MULTILINE)
-        
+
         # Fix escaped hyphens: '\-' -> '-'
         markdown = re.sub(r'\\-', '-', markdown)
-        
+
         # Fix spaces before punctuation after bold/italic: '**text** ,' -> '**text**,'
         markdown = re.sub(r'\*\*([^*]+)\*\* ([,.:;!?])', r'**\1**\2', markdown)
         markdown = re.sub(r'\*([^*]+)\* ([,.:;!?])', r'*\1*\2', markdown)
-        
+
         # Fix spaces after bold at start of definitions: '**Triggers** :' -> '**Triggers**:'
         markdown = re.sub(r'\*\*([^*]+)\*\* :', r'**\1**:', markdown)
-        
+
         # Fix extra spaces after bold/italic
         markdown = re.sub(r'\*\*([^*]+)\*\*  +', r'**\1** ', markdown)
-        
+
         # Convert indented code blocks to fenced code blocks
         lines = markdown.split('\n')
         in_code_block = False
         result_lines = []
         code_buffer = []
-        
+
         i = 0
         while i < len(lines):
             line = lines[i]
             stripped = line.lstrip()
             indent = len(line) - len(stripped)
-            
+
             if not in_code_block:
                 if indent >= 4 and stripped:
                     is_code_block = False
@@ -165,7 +188,7 @@ def main():
                         next_indent = len(next_line) - len(next_stripped)
                         if next_indent >= 4 or next_line.strip() == '':
                             is_code_block = True
-                    
+
                     if is_code_block:
                         in_code_block = True
                         result_lines.append('```')
@@ -188,28 +211,28 @@ def main():
                     code_buffer = []
                     in_code_block = False
                     result_lines.append(line)
-            
+
             i += 1
-        
+
         if in_code_block:
             while code_buffer and code_buffer[-1] == '':
                 code_buffer.pop()
             result_lines.extend(code_buffer)
             result_lines.append('```')
-        
+
         markdown = '\n'.join(result_lines)
-        
+
         # Clean up excessive blank lines (3+ -> 2)
         markdown = re.sub(r'\n{3,}', '\n\n', markdown)
-        
+
         # Remove trailing whitespace from lines
         markdown = '\n'.join(line.rstrip() for line in markdown.split('\n'))
-        
+
         # Ensure file ends with single newline
         markdown = markdown.strip() + '\n'
-        
+
         print(markdown, end='')
-        
+
     except json.JSONDecodeError as e:
         print(f'Error: Failed to parse JSON: {e}', file=sys.stderr)
         sys.exit(1)


### PR DESCRIPTION
- Update payload parsing to fall back through codeViewBlobRoute and
  codeViewBlobLayoutRoute.StyledBlob paths introduced in GitHub's 2025
  page structure, while retaining the old payload.blob fallback.
- Rewrite convert_frontmatter_table_to_yaml to handle GitHub's new
  2-column vertical table format (key | value per row) instead of the
  old 3-column horizontal format, fixing swapped key/value output.

https://claude.ai/code/session_01GHjJN6AQA5pF88TQNkSSDF