### PR TITLE
chore: exclude *.bak from package-skill.sh

### DIFF
--- a/scripts/package-skill.sh
+++ b/scripts/package-skill.sh
@@ -34,7 +34,9 @@ zip -r professor-synapse.zip professor-synapse/ \
     -x "professor-synapse/.DS_Store" \
     -x "professor-synapse/**/.DS_Store" \
     -x "professor-synapse/**/*.pyc" \
-    -x "professor-synapse/**/__pycache__/*"
+    -x "professor-synapse/**/__pycache__/*" \
+    -x "professor-synapse/**/*.bak" \
+    -x "professor-synapse/memory/memory.json.bak"
 
 echo ""
 echo "✅ Created: $OUTPUT_FILE"


### PR DESCRIPTION
`scripts/package-skill.sh` now excludes `*.bak` and `memory/memory.json.bak`, so the documented `bash scripts/package-skill.sh` reproduces the clean zip this v2.0.0 release was packaged with (no stray memory backup can leak into the distributed skill).

🤖 Generated with [Claude Code](https://claude.com/claude-code)