### PR TITLE
fix: accept comma- or space-separated tags/people

### DIFF
--- a/professor-synapse/references/changelog.md
+++ b/professor-synapse/references/changelog.md
@@ -4,6 +4,10 @@ Version history for the Professor Synapse skill. Check this after fetching updat
 
 ---
 
+## Unreleased
+
+- **Tag/people parsing accepts comma- or space-separated values.** `--tags test,install` now stores two distinct tags (`["test", "install"]`), the same as `--tags test install`. Previously a comma-separated string landed as one tag. Normalization applies to all list-valued options (`--tags`, `--people`, `--query`, `--focus-areas`, `--archive`, `--drop`). Added a regression test (26 cases total).
+
 ## v2.0.0 — 2026-06-13
 
 Major version marking the memory architecture and the script-driven update pipeline as the new baseline. Consolidates the v1.1.0 memory work with a one-command updater and removes the legacy HTML-scraping update path.

--- a/professor-synapse/references/memory-protocol.md
+++ b/professor-synapse/references/memory-protocol.md
@@ -26,7 +26,7 @@ If you'd rather surface things step by step:
 - Working items: `add --agent <slug> --text "..." [--type ...] [--people ...] [--tags ...] [--due ...]`.
 - Things born straight into long-term: `record --agent <slug> --kind decision|note|fact --text "..." [--rationale ...] [--people ...] [--tags ...]`. Use `fact` for durable things learned about the user, `decision` for choices with a rationale, `note` for context.
 
-Always fill `--people` and `--tags`; they power recall. Tag with the acting agent so the entry can be filtered later.
+Always fill `--people` and `--tags`; they power recall. Tag with the acting agent so the entry can be filtered later. List options accept either form — `--tags a b` or `--tags a,b` both store two distinct tags.
 
 ## Janitor (keep it from going stale)
 

--- a/professor-synapse/scripts/memory.py
+++ b/professor-synapse/scripts/memory.py
@@ -866,8 +866,32 @@ DISPATCH = {
 }
 
 
+# List-valued options use nargs="*", so they accept space-separated values
+# (--tags a b). Agents and users also naturally type comma-separated values
+# (--tags a,b) — normalize both forms to a clean list of distinct tokens.
+_MULTI_FIELDS = ("people", "tags", "query", "focus_areas", "archive", "drop")
+
+
+def _split_multi(values):
+    out = []
+    for v in values:
+        for part in str(v).split(","):
+            part = part.strip()
+            if part:
+                out.append(part)
+    return out
+
+
+def normalize_multi(args):
+    for field in _MULTI_FIELDS:
+        val = getattr(args, field, None)
+        if val is not None:
+            setattr(args, field, _split_multi(val))
+    return args
+
+
 def main(argv=None):
-    args = build_parser().parse_args(argv)
+    args = normalize_multi(build_parser().parse_args(argv))
     DISPATCH[args.cmd](args.root, args)
 
 

--- a/professor-synapse/scripts/test_memory.py
+++ b/professor-synapse/scripts/test_memory.py
@@ -98,6 +98,18 @@ class WorkingMemory(MemTest):
         self.assertEqual(item["text"], "final")
         self.assertEqual(item["tags"], ["x", "y"])
 
+    def test_tags_comma_or_space_separated(self):
+        # An agent may type --tags a,b OR --tags a b; both must yield distinct tags.
+        self.cli("--agent", "a", "add", "--text", "comma form", "--tags", "test,install")
+        self.cli("--agent", "a", "add", "--text", "space form", "--tags", "test", "install")
+        self.cli("--agent", "a", "add", "--text", "mixed form",
+                 "--tags", "test, install", "extra")
+        active = self.cli_json("read")["active"]
+        by_text = {i["text"]: i["tags"] for i in active}
+        self.assertEqual(by_text["comma form"], ["test", "install"])
+        self.assertEqual(by_text["space form"], ["test", "install"])
+        self.assertEqual(by_text["mixed form"], ["test", "install", "extra"])
+
 
 class LongTerm(MemTest):
     def test_record_then_query(self):


### PR DESCRIPTION
## Summary

A v2.0.0 Desktop self-check surfaced that `--tags test,install` stored a single tag `"test,install"` rather than two. The list options use `nargs="*"` (space-separated), so a comma-joined token wasn't split.

`normalize_multi()` now runs at the parse boundary and splits every list-valued option (`--tags`, `--people`, `--query`, `--focus-areas`, `--archive`, `--drop`) on commas as well as spaces — `--tags a b`, `--tags a,b`, and `--tags "a, b" c` all yield distinct tokens.

## Testing
- New regression test `test_tags_comma_or_space_separated` (comma / space / mixed forms)
- Full suite: 26/26 green
- Live repro: `record --tags test,install` → stored `["test", "install"]`

SKILL.md stays at 2.0.0; `## Unreleased` changelog entry pending a version cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)