### PR TITLE
Fix data-root resolution deadlock when multiple plugin data dirs exist

### DIFF
--- a/professor-synapse-plugin/skills/professor-synapse/scripts/_pluginpaths.py
+++ b/professor-synapse-plugin/skills/professor-synapse/scripts/_pluginpaths.py
@@ -19,7 +19,8 @@ Resolution order:
          ->  ~/.claude/plugins/data/<plugin>-<marketplace>/
      (matches how Claude Code names the data dir; no env var needed.)
   3. Glob <plugins>/data/<plugin>-*  — marketplace-name agnostic; used if (2)'s exact
-     layout assumption ever shifts but a single data dir for this plugin still exists.
+     layout assumption ever shifts. On multiple matches (e.g. a stale dir from an
+     earlier install flavor) the most recently modified dir wins — see _glob_data.
   4. In-place fallback: the skill root itself — so the very same files keep working as
      a plain portable skill (or in a dev checkout) with no plugin involved.
 
@@ -66,13 +67,26 @@ def _derive_from_cache(here: Path):
 
 
 def _glob_data(here: Path):
-    """Find exactly one <plugins>/data/<plugin>-* dir, else None."""
+    """Find the <plugins>/data/<plugin>-* dir; on ambiguity prefer the live one.
+
+    Ambiguity happens in the wild: a stale leftover data dir from an earlier
+    install flavor (e.g. <plugin>-inline) can sit beside the live
+    <plugin>-<marketplace> dir. Returning None in that case silently sends
+    model-side writes (the summon marker, the memory store) to the in-place
+    fallback while hooks — which get $CLAUDE_PLUGIN_DATA injected — keep
+    reading the real data dir: the summon-gate never opens and the memory
+    store forks. Prefer the most recently modified match instead — the live
+    dir keeps receiving hook writes, so recency identifies it."""
     plugins_root = _plugins_root_from(here.parts) or (Path.home() / ".claude" / "plugins")
     data_root = plugins_root / "data"
     if not data_root.is_dir():
         return None
     matches = sorted(p for p in data_root.glob(f"{PLUGIN_NAME}-*") if p.is_dir())
-    return matches[0] if len(matches) == 1 else None
+    if not matches:
+        return None
+    if len(matches) > 1:
+        matches.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+    return matches[0]
 
 
 def resolve_data_root(skill_root) -> str:


### PR DESCRIPTION
## The failure mode

`_glob_data` requires **exactly one** `<plugins>/data/<plugin>-*` match and returns `None` otherwise. In the wild, a stale leftover data dir from an earlier install flavor (e.g. `professor-synapse-inline`) can sit beside the live `<plugin>-<marketplace>` dir. When that happens:

- **Hooks** (summon-gate, memory-nudge, persona-guard) receive `$CLAUDE_PLUGIN_DATA` injected and keep using the **real data dir**.
- **Model-run scripts** (`summon.py`, `memory.py`) do NOT receive that env var (documented in this module's own header), hit the ambiguous glob, get `None`, and silently fall back to the **in-place skill root**.

Two components, two directories. Observed consequences on a real workstation (2026-08-25):

1. **Summon-gate deadlock** — `summon.py` writes its marker in-place and prints "gate satisfied", but the PreToolUse hook reads the data dir and blocks every file edit, no matter how many times the agent re-summons.
2. **Forked memory store** — `memory.py` writes to an in-place `memory/` store while the data-dir store freezes; on this machine the two databases diverged for a week (17 vs 10 records, zero overlap) before the split was noticed.

## The fix

On multiple matches, prefer the **most recently modified** dir — the live dir keeps receiving hook writes, so recency identifies it. Zero matches still returns `None`; the single-match fast path is unchanged.

Diagnosed by tracing `write_summon_marker` (summon.py) against `resolve_marker` (hooks/summon-gate.py) on the affected machine; recovery there required deleting the stale dir and migrating the forked store record-by-record through the `memory.py` CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
